### PR TITLE
Change the way expressions are formulated

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: ompr
 Type: Package
 Title: R optimization modelling project
-Version: 0.2.2
+Version: 0.3.0
 Authors@R: person("Dirk", "Schumacher", email = "mail@dirk-schumacher.net",
             role = c("aut", "cre"))
 Maintainer: Dirk Schumacher <mail@dirk-schumacher.net>

--- a/R/class-model.R
+++ b/R/class-model.R
@@ -219,9 +219,8 @@ setMethod("show", signature(object = "Model"),
 #' Add one or more constraints to the model using quantifiers.
 #'
 #' @param model the model
-#' @param lhs the linear objective as a sum of variables and constants
-#' @param direction either "<=", ">=" or "=="
-#' @param rhs the linear objective as a sum of variables and constants
+#' @param constraint_expr the constraint. Must be a linear (in)equality with
+#'        operator "<=", "==" or ">=".
 #' @param .show_progress_bar displays a progressbar when adding multiple
 #'                           constraints
 #' @param ... quantifiers for the indexed variables. For all combinations of
@@ -233,14 +232,22 @@ setMethod("show", signature(object = "Model"),
 #' library(magrittr)
 #' MIPModel() %>%
 #'  add_variable(x[i], i = 1:5) %>%
-#'  add_constraint(x[i], ">=", 1, i = 1:5) # creates 5 constraints
+#'  add_constraint(x[i] >= 1, i = 1:5) # creates 5 constraints
 #'
 #' @export
 setGeneric("add_constraint", function(model,
-                                      lhs, direction, rhs,
+                                      constraint_expr,
                                       .show_progress_bar = TRUE, ...) {
-  lhs_ast <- substitute(lhs)
-  rhs_ast <- substitute(rhs)
+  constraint_ast <- substitute(constraint_expr)
+  direction <- as.character(constraint_ast[[1]])
+  if (!direction %in% c(">=", "<=", "==")) {
+    stop("Does not recognize constraint expr. Missing the constraint relation")
+  }
+  if (length(constraint_ast) != 3) {
+    stop("constraint not well formed. Must be a linear (in)equality.")
+  }
+  lhs_ast <- constraint_ast[[2]]
+  rhs_ast <- constraint_ast[[3]]
   parent_env <- parent.frame()
   bound_subscripts <- list(...)
   add_constraint_internal <- function(envir = parent_env) {

--- a/R/class-model.R
+++ b/R/class-model.R
@@ -239,12 +239,12 @@ setGeneric("add_constraint", function(model,
                                       constraint_expr,
                                       .show_progress_bar = TRUE, ...) {
   constraint_ast <- substitute(constraint_expr)
+  if (length(constraint_ast) != 3) {
+    stop("constraint not well formed. Must be a linear (in)equality.")
+  }
   direction <- as.character(constraint_ast[[1]])
   if (!direction %in% c(">=", "<=", "==")) {
     stop("Does not recognize constraint expr. Missing the constraint relation")
-  }
-  if (length(constraint_ast) != 3) {
-    stop("constraint not well formed. Must be a linear (in)equality.")
   }
   lhs_ast <- constraint_ast[[2]]
   rhs_ast <- constraint_ast[[3]]
@@ -263,14 +263,6 @@ setGeneric("add_constraint", function(model,
       stop(paste0("The right-hand-side is probably non-linear. ",
                   "Currently, only linear constraints are ",
                   "supported."))
-    }
-    if (any_unbounded_indexes(lhs_ast)) {
-      stop(paste0("Some variable indexes are unbounded",
-                  " left hand expression."))
-    }
-    if (any_unbounded_indexes(rhs_ast)) {
-      stop(paste0("Some variable indexes are unbounded",
-                  " in the right hand expression."))
     }
     direction <- if (direction == "=") "==" else direction
     new("Constraint", lhs = as.expression(lhs_ast),

--- a/R/helper.R
+++ b/R/helper.R
@@ -135,31 +135,6 @@ bind_variables <- function(model, ast, calling_env) {
   eval(substitute(substitute(x, calling_env), list(x = ast)))
 }
 
-# checks if an ast has unbounded index
-# i.e. unevaluated ones
-any_unbounded_indexes <- function(ast) {
-  unbounded_indexes <- FALSE
-  on_element <- function(push, inplace_update_ast, get_ast_value, element) {
-    local_ast <- element$ast
-    path <- element$path
-    if (is.call(local_ast)) {
-      if (local_ast[[1]] == "[") {
-        for (i in 3:length(local_ast)) {
-          if (is.name(local_ast[[i]])) {
-            return(unbounded_indexes <<- TRUE)
-          }
-        }
-      } else if (!unbounded_indexes) {
-        for (i in 3:length(local_ast)) {
-          push(list(ast = local_ast[[i]], path = c(path, i)))
-        }
-      }
-    }
-  }
-  ast_walker(ast, on_element)
-  unbounded_indexes
-}
-
 check_expression <- function(model, the_ast) {
   on_element <- function(push, inplace_update_ast, get_ast_value, element) {
     ast <- element$ast

--- a/man/add_constraint.Rd
+++ b/man/add_constraint.Rd
@@ -4,16 +4,13 @@
 \alias{add_constraint}
 \title{Add a constraint}
 \usage{
-add_constraint(model, lhs, direction, rhs, .show_progress_bar = TRUE, ...)
+add_constraint(model, constraint_expr, .show_progress_bar = TRUE, ...)
 }
 \arguments{
 \item{model}{the model}
 
-\item{lhs}{the linear objective as a sum of variables and constants}
-
-\item{direction}{either "<=", ">=" or "=="}
-
-\item{rhs}{the linear objective as a sum of variables and constants}
+\item{constraint_expr}{the constraint. Must be a linear (in)equality with
+operator "<=", "==" or ">=".}
 
 \item{.show_progress_bar}{displays a progressbar when adding multiple
 constraints}
@@ -31,7 +28,7 @@ Add one or more constraints to the model using quantifiers.
 library(magrittr)
 MIPModel() \%>\%
  add_variable(x[i], i = 1:5) \%>\%
- add_constraint(x[i], ">=", 1, i = 1:5) # creates 5 constraints
+ add_constraint(x[i] >= 1, i = 1:5) # creates 5 constraints
 
 }
 

--- a/tests/testthat/test-helpers.R
+++ b/tests/testthat/test-helpers.R
@@ -5,10 +5,6 @@ test_that("sum_exp returns an ast", {
   expect_equal(deparse(result), "x[1L] + x[2L] + x[3L]")
 })
 
-test_that("any_unbounded_indexes detects unbound vars", {
-  expect_true(any_unbounded_indexes(substitute(x[2, i])))
-})
-
 test_that("sum_exp does not evaluate other variables", {
   weights <- c(1, 2, 3)
   n <- 3

--- a/tests/testthat/test-model.R
+++ b/tests/testthat/test-model.R
@@ -317,3 +317,8 @@ test_that("solve_model warns about wrong arguments", {
   m <- MIPModel()
   expect_error(solve_model(m, not_a_fun <- 0), regexp = "function")
 })
+
+test_that("add_constraint only accepts linear inequalities", {
+  m <- add_variable(new("Model"), x, type = "binary")
+  expect_error(add_constraint(m, x))
+})

--- a/tests/testthat/test-model.R
+++ b/tests/testthat/test-model.R
@@ -82,24 +82,23 @@ test_that("obj. function can bind external variables", {
 test_that("we can add constraints", {
   m <- new("Model")
   m <- add_variable(m, x[i], i = 1:10, type = "binary")
-  m <- add_constraint(m, x[3], "<=", x[6])
+  m <- add_constraint(m, x[3] <= x[6])
 })
 
 test_that("add_constraint only allows a fixed set of directions", {
   m <- new("Model")
   m <- add_variable(m, x[i], i = 1:10, type = "binary")
-  add_constraint(m, x[3], "<=", x[6])
-  add_constraint(m, x[3], ">=", x[6])
-  add_constraint(m, x[3], "=", x[6])
-  add_constraint(m, x[3], "==", x[6])
-  expect_error(add_constraint(m, x[3], "<", x[6]))
-  expect_error(add_constraint(m, x[3], ">", x[6]))
-  expect_error(add_constraint(m, x[3], "wat", x[6]))
+  add_constraint(m, x[3] <= x[6])
+  add_constraint(m, x[3] >= x[6])
+  add_constraint(m, x[3] == x[6])
+  expect_error(add_constraint(m, x[3] < x[6]))
+  expect_error(add_constraint(m, x[3] > x[6]))
+  expect_error(add_constraint(m, x[3] + x[6]))
 })
 
 test_that("we can add complicated constraints", {
   m <- add_variable(new("Model"), x[i], i = 1:3, type = "binary")
-  m <- add_constraint(m, sum_exp(x[i], i = 1:2) + x[3], "==", 1)
+  m <- add_constraint(m, sum_exp(x[i], i = 1:2) + x[3] == 1)
   expect_equal(length(m@constraints), 1)
   constraint <- m@constraints[[1]]
   expect_equal(constraint@rhs[[1]], 1)
@@ -107,21 +106,14 @@ test_that("we can add complicated constraints", {
   expect_equal(deparse(constraint@lhs[[1]]), "x[1L] + x[2L] + x[3]")
 })
 
-test_that("add_constraint converts = to ==", {
-  m <- add_variable(new("Model"), x[i], i = 1:3, type = "binary")
-  m <- add_constraint(m, sum_exp(x[i], i = 1:2) + x[3], "=", 1)
-  constraint <- m@constraints[[1]]
-  expect_equal(constraint@direction, "==")
-})
-
 test_that("add_constraint throws an error if constraints are non-linear lhs", {
   m <- add_variable(new("Model"), x[i], i = 1:3, type = "binary")
-  expect_error(add_constraint(m, sum_exp(x[i], i = 1:2) * x[3], "==", 1))
+  expect_error(add_constraint(m, sum_exp(x[i], i = 1:2) * x[3] == 1))
 })
 
 test_that("add_constraint throws an error if constraints are non-linear rhs", {
   m <- add_variable(new("Model"), x[i], i = 1:3, type = "binary")
-  expect_error(add_constraint(m, 1, "==", sum_exp(x[i], i = 1:2) * x[3]))
+  expect_error(add_constraint(m, 1 == sum_exp(x[i], i = 1:2) * x[3]))
 })
 
 test_that("set_objective throws an error if it is non-linear", {
@@ -131,7 +123,7 @@ test_that("set_objective throws an error if it is non-linear", {
 
 test_that("we can solve a model", {
   m <- add_variable(new("Model"), x[i], i = 1:3, type = "binary")
-  m <- add_constraint(m, sum_exp(x[i], i = 1:3), "==", 1)
+  m <- add_constraint(m, sum_exp(x[i], i = 1:3) == 1)
   m <- set_objective(m, x[1])
   solution <- new("Solution")
   result <- solve_model(m, function(model) {
@@ -143,7 +135,7 @@ test_that("we can solve a model", {
 
 test_that("it works with magrittr pipes", {
   m <- add_variable(new("Model"), x[i], i = 1:3, type = "binary") %>%
-    add_constraint(sum_exp(x[i], i = 1:3), "==", 1) %>%
+    add_constraint(sum_exp(x[i], i = 1:3) == 1) %>%
     set_objective(x[1])
   expect_equal(length(m@variables), 1)
 })
@@ -179,32 +171,32 @@ test_that("throw error if lower bound > upper bound", {
 test_that("add_constraint can handle a for all quantifier", {
   m <- new("Model") %>%
     add_variable(x[i, j], i = 1:3, j = 1:3) %>%
-    add_constraint(sum_exp(x[i, j], j = 1:3), "==", 1, i = 1:3)
+    add_constraint(sum_exp(x[i, j], j = 1:3) == 1, i = 1:3)
   expect_equal(length(m@constraints), 3)
 })
 
 test_that("add_constraint warns about unbouded all quantifier", {
   m <- new("Model") %>%
     add_variable(x[i, j], i = 1:3, j = 1:3)
-  expect_error(add_constraint(sum_exp(x[i, j], j = 1:3), "==", 1, e = 1:3))
+  expect_error(add_constraint(sum_exp(x[i, j], j = 1:3) == 1, e = 1:3))
 })
 
 test_that("add_constraint warns about unbouded all quantifier in rhs", {
   m <- new("Model") %>%
     add_variable(x[i, j], i = 1:3, j = 1:3)
-  expect_error(add_constraint(1, "==", sum_exp(x[i, j], j = 1:3), e = 1:3))
+  expect_error(add_constraint(1 == sum_exp(x[i, j], j = 1:3), e = 1:3))
 })
 
 test_that("add_constraints throws error if unbounded indexes in lhs", {
   m <- new("Model") %>%
     add_variable(x[i, j], i = 1:3, j = 1:3)
-  expect_error(add_constraint(x[1, j], "==", 1))
+  expect_error(add_constraint(x[1, j] == 1))
 })
 
 test_that("add_constraints throws error if unbounded indexes in rhs", {
   m <- new("Model") %>%
     add_variable(x[i, j], i = 1:3, j = 1:3)
-  expect_error(add_constraint(1, "==", x[1, j]))
+  expect_error(add_constraint(1 == x[1, j]))
 })
 
 test_that("bounded vars in add_constraints should take precedence", {
@@ -212,7 +204,7 @@ test_that("bounded vars in add_constraints should take precedence", {
     add_variable(x[i, j], i = 1:3, j = 1:3)
   j <- 1
   i <- 1
-  m <- add_constraint(m, sum_exp(x[i, j], j = 3), "==", 1)
+  m <- add_constraint(m, sum_exp(x[i, j], j = 3) == 1)
   expect_equal(m@constraints[[1]]@lhs, expression(x[1, 3]))
 })
 
@@ -224,23 +216,23 @@ test_that("we can model a tsp", {
     add_variable(x[i, j], i = 1:cities, j = 1:cities, type = "binary") %>%
     set_objective(sum_exp(distance_matrix[i, j] * x[i, j],
                           i = 1:cities, j = 1:cities), direction = "min") %>%
-    add_constraint(x[i, i], "==", 0, i = 1:cities) %>%
-    add_constraint(x[i, j], "==", x[j, i], i = 1:cities, j = 1:cities) %>%
-    add_constraint(sum_exp(x[i, j], i = sub_tours[[s]], j = sub_tours[[s]]),
-                   "<=", length(sub_tours[s]) - 1, s = 1:length(sub_tours))
+    add_constraint(x[i, i] == 0, i = 1:cities) %>%
+    add_constraint(x[i, j] == x[j, i], i = 1:cities, j = 1:cities) %>%
+    add_constraint(sum_exp(x[i, j], i = sub_tours[[s]], j = sub_tours[[s]]) <=
+                     length(sub_tours[s]) - 1, s = 1:length(sub_tours))
 })
 
 test_that("bug 20160701: -x as a formula", {
   add_variable(MIPModel(), x, type = "continuous", lb = 4) %>%
     add_variable(y, type = "continuous", ub = 4) %>%
-    add_constraint(x + y, "<=", 10) %>%
+    add_constraint(x + y <= 10) %>%
     set_objective(-x + y, direction = "max")
 })
 
 test_that("model has a nice default output", {
   m <- add_variable(MIPModel(), x, type = "continuous", lb = 4) %>%
     add_variable(y, type = "continuous", ub = 4) %>%
-    add_constraint(x + y, "<=", 10) %>%
+    add_constraint(x + y <= 10) %>%
     set_objective(-x + y, direction = "max")
   expect_output(show(m), "Constraints: 1")
 })
@@ -248,7 +240,7 @@ test_that("model has a nice default output", {
 test_that("multiplications in objective fun", {
   m <- add_variable(MIPModel(), x, type = "continuous", lb = 4) %>%
     add_variable(y, type = "continuous", ub = 4) %>%
-    add_constraint(x + y, "<=", 10) %>%
+    add_constraint(x + y <= 10) %>%
     set_objective(5 * (-x + y), direction = "max")
   expect_equal(deparse(m@objective@expression[[1]]), "-5 * x + 5 * y")
 })
@@ -261,7 +253,7 @@ test_that("model output works without an obj. function", {
 test_that("devision in objective fun", {
   m <- add_variable(MIPModel(), x, type = "continuous", lb = 4) %>%
     add_variable(y, type = "continuous", ub = 4) %>%
-    add_constraint(x + y, "<=", 10) %>%
+    add_constraint(x + y <= 10) %>%
     set_objective(5 / (-x + y), direction = "max")
   expect_equal(deparse(m@objective@expression[[1]]), "-0.2 * x + 0.2 * y")
 })
@@ -269,7 +261,7 @@ test_that("devision in objective fun", {
 test_that("constraints should be saved with only + operators", {
   m <- add_variable(MIPModel(), x, type = "continuous", lb = 4) %>%
     add_variable(y, type = "continuous", ub = 4) %>%
-    add_constraint(x - y, "<=", 10) %>%
+    add_constraint(x - y <= 10) %>%
     set_objective(5 / (-x + y), direction = "max")
   expect_equal(deparse(m@constraints[[1]]@lhs[[1]]), "x + -1 * y")
 })
@@ -277,7 +269,7 @@ test_that("constraints should be saved with only + operators", {
 test_that("constraints can have an unary + operator", {
   m <- add_variable(MIPModel(), x, type = "continuous", lb = 4) %>%
     add_variable(y, type = "continuous", ub = 4) %>%
-    add_constraint(+x - y, "<=", 10) %>%
+    add_constraint(+x - y <= 10) %>%
     set_objective(5 / (-x + y), direction = "max")
   expect_equal(deparse(m@constraints[[1]]@lhs[[1]]), "1 * x + -1 * y")
 })
@@ -287,13 +279,13 @@ test_that("small to mid sized models should work", {
   result <- MIPModel() %>%
     add_variable(x[i], i = 1:n, type = "binary") %>%
     set_objective(sum_exp(x[i], i = 1:n), "max") %>%
-    add_constraint(sum_exp(x[i], i = 1:n), "==", 1)
+    add_constraint(sum_exp(x[i], i = 1:n) == 1)
 })
 
 test_that("bug 20160713 #41: quantifiers in constraints in sum_exp", {
   MIPModel() %>%
     add_variable(x[i], i = 1:9) %>%
-    add_constraint(sum_exp(x[i], i = 1:3 + y), "==", 1, y = c(0, 3, 6))
+    add_constraint(sum_exp(x[i], i = 1:3 + y) == 1, y = c(0, 3, 6))
 })
 
 test_that("small to mid sized model should work #2", {
@@ -301,13 +293,13 @@ test_that("small to mid sized model should work #2", {
   coef <- matrix(1:(n ^ 2), ncol = 2)
   MIPModel() %>%
     add_variable(x[i, j], i = 1:n, j = 1:n) %>%
-    add_constraint(sum_exp(coef[i, j] * x[i, j], i = 1:n, j = 1:n), "==", 1)
+    add_constraint(sum_exp(coef[i, j] * x[i, j], i = 1:n, j = 1:n) == 1)
 })
 
 test_that("bug 20160729: two sum_exp on one side", {
   m <- MIPModel() %>%
     add_variable(x[j], j = 1:4) %>%
-    add_constraint(sum_exp(x[j], j = 1:2) - sum_exp(x[j], j = 3:4), "==", 0)
+    add_constraint(sum_exp(x[j], j = 1:2) - sum_exp(x[j], j = 3:4) == 0)
   expect_equal(deparse(m@constraints[[1]]@lhs[[1]]),
                "x[1L] + x[2L] + (-1 * x[3L] + -1 * x[4L])")
 })
@@ -316,8 +308,8 @@ test_that("bug 20160729_2: external var binding", {
   x <- 1:10
   m <- MIPModel() %>%
     add_variable(x[j], j = 1:2)
-  expect_warning(add_constraint(m, sum_exp(x[j], j = 1:2), "==", 0))
-  expect_warning(add_constraint(m, sum_exp(x[j], j = 1:2), "==", 0),
+  expect_warning(add_constraint(m, sum_exp(x[j], j = 1:2) == 0))
+  expect_warning(add_constraint(m, sum_exp(x[j], j = 1:2) == 0),
                  regexp = "x")
 })
 

--- a/tests/testthat/test-solution.R
+++ b/tests/testthat/test-solution.R
@@ -4,7 +4,7 @@ test_that("export single var to numeric", {
  model <- MIPModel() %>%
    add_variable(x, ub = 1) %>%
    add_variable(y, ub = 1) %>%
-   add_constraint(x + y, "<=", 1) %>%
+   add_constraint(x + y <= 1) %>%
    set_objective(x + y)
  solution <- new("Solution",
                              status = "optimal",

--- a/vignettes/problem-mtsp.Rmd
+++ b/vignettes/problem-mtsp.Rmd
@@ -89,27 +89,27 @@ model <- MIPModel() %>%
   set_objective(sum_exp(distance[i, j] * x[i, j, k], i = 1:n, j = 1:n, k = 1:m), "min") %>%
   
   # you cannot go to the same city
-  add_constraint(x[i, i, k], "==", 0, i = 1:n, k = 1:m) %>%
+  add_constraint(x[i, i, k] == 0, i = 1:n, k = 1:m) %>%
   
   # each salesman needs to leave the depot
-  add_constraint(sum_exp(x[1, j, k], j = 2:n), "==", 1, k = 1:m) %>%
+  add_constraint(sum_exp(x[1, j, k], j = 2:n) == 1, k = 1:m) %>%
   
   # each salesman needs to come back to the depot
-  add_constraint(sum_exp(x[i, 1, k], i = 2:n), "==", 1, k = 1:m) %>%
+  add_constraint(sum_exp(x[i, 1, k], i = 2:n) == 1, k = 1:m) %>%
   
   # if a salesman comes to a city he has to leave it as well
-  add_constraint(sum_exp(x[j, i, k], j = 1:n), "==", sum_exp(x[i, j, k], j = 1:n), i = 2:n, k = 1:m) %>%
+  add_constraint(sum_exp(x[j, i, k], j = 1:n) == sum_exp(x[i, j, k], j = 1:n), i = 2:n, k = 1:m) %>%
   
   
   # leave each city with only one salesman
-  add_constraint(sum_exp(x[i, j, k], j = 1:n, k = 1:m), "==", 1, i = 2:n) %>% 
+  add_constraint(sum_exp(x[i, j, k], j = 1:n, k = 1:m) == 1, i = 2:n) %>% 
   
   # arrive at each city with only one salesman
-  add_constraint(sum_exp(x[i, j, k], i = 1:n, k = 1:m), "==", 1, j = 2:n) %>% 
+  add_constraint(sum_exp(x[i, j, k], i = 1:n, k = 1:m) == 1, j = 2:n) %>% 
   
   # ensure no subtours (arc constraints)
-  add_constraint(u[i, k], ">=", 2, i = 2:n, k = 1:m) %>% 
-  add_constraint(u[i, k] - u[j, k] + 1, "<=", (n - 1) * (1 - x[i, j, k]), i = 2:n, j = 2:n, k = 1:m)
+  add_constraint(u[i, k] >= 2, i = 2:n, k = 1:m) %>% 
+  add_constraint(u[i, k] - u[j, k] + 1 <= (n - 1) * (1 - x[i, j, k]), i = 2:n, j = 2:n, k = 1:m)
 model
 ```
 

--- a/vignettes/problem-sudoku.Rmd
+++ b/vignettes/problem-sudoku.Rmd
@@ -33,16 +33,16 @@ model <- MIPModel() %>%
   set_objective(0) %>%
   
   # only one number can be assigned per cell
-  add_constraint(sum_exp(x[i, j, k], k = 1:9), "==", 1, i = 1:n, j = 1:n) %>%
+  add_constraint(sum_exp(x[i, j, k], k = 1:9) == 1, i = 1:n, j = 1:n) %>%
   
   # each number is exactly once in a row
-  add_constraint(sum_exp(x[i, j, k], j = 1:n), "==", 1, i = 1:n, k = 1:9) %>%
+  add_constraint(sum_exp(x[i, j, k], j = 1:n) == 1, i = 1:n, k = 1:9) %>%
   
   # each number is exactly once in a column
-  add_constraint(sum_exp(x[i, j, k], i = 1:n), "==", 1, j = 1:n, k = 1:9) %>% 
+  add_constraint(sum_exp(x[i, j, k], i = 1:n) == 1, j = 1:n, k = 1:9) %>% 
   
   # each 3x3 square must have all numbers
-  add_constraint(sum_exp(x[i, j, k], i = 1:3 + sx, j = 1:3 + sy), "==", 1, 
+  add_constraint(sum_exp(x[i, j, k], i = 1:3 + sx, j = 1:3 + sy) == 1, 
                  sx = seq(0, n - 3, 3), sy = seq(0, n - 3, 3), k = 1:9)
 model
 ```
@@ -70,15 +70,15 @@ If you want to solve a concrete sudoku you can fix certain cells to specific val
 
 ```{r}
 model_fixed <- model %>% 
-  add_constraint(x[1, 1, 1], "==", 1) %>% 
-  add_constraint(x[1, 2, 2], "==", 1) %>% 
-  add_constraint(x[1, 3, 3], "==", 1) %>% 
-  add_constraint(x[2, 1, 4], "==", 1) %>% 
-  add_constraint(x[2, 2, 5], "==", 1) %>% 
-  add_constraint(x[2, 3, 6], "==", 1) %>% 
-  add_constraint(x[3, 1, 7], "==", 1) %>% 
-  add_constraint(x[3, 2, 8], "==", 1) %>% 
-  add_constraint(x[3, 3, 9], "==", 1)
+  add_constraint(x[1, 1, 1] == 1) %>% 
+  add_constraint(x[1, 2, 2] == 1) %>% 
+  add_constraint(x[1, 3, 3] == 1) %>% 
+  add_constraint(x[2, 1, 4] == 1) %>% 
+  add_constraint(x[2, 2, 5] == 1) %>% 
+  add_constraint(x[2, 3, 6] == 1) %>% 
+  add_constraint(x[3, 1, 7] == 1) %>% 
+  add_constraint(x[3, 2, 8] == 1) %>% 
+  add_constraint(x[3, 3, 9] == 1)
 result <- solve_model(model_fixed, with_ROI(solver = "glpk", verbose = TRUE))
 
 result %>% 

--- a/vignettes/problem-tsp.Rmd
+++ b/vignettes/problem-tsp.Rmd
@@ -90,17 +90,17 @@ model <- MIPModel() %>%
   set_objective(sum_exp(distance[i, j] * x[i, j], i = 1:n, j = 1:n), "min") %>%
   
   # you cannot go to the same city
-  add_constraint(x[i, i], "==", 0, i = 1:n) %>%
+  add_constraint(x[i, i] == 0, i = 1:n) %>%
   
   # leave each city
-  add_constraint(sum_exp(x[i, j], j = 1:n), "==", 1, i = 1:n) %>%
+  add_constraint(sum_exp(x[i, j], j = 1:n) == 1, i = 1:n) %>%
   
   # visit each city
-  add_constraint(sum_exp(x[i, j], i = 1:n), "==", 1, j = 1:n) %>%
+  add_constraint(sum_exp(x[i, j], i = 1:n) == 1, j = 1:n) %>%
   
   # ensure no subtours (arc constraints)
-  add_constraint(u[i], ">=", 2, i = 2:n) %>% 
-  add_constraint(u[i] - u[j] + 1, "<=", (n - 1) * (1 - x[i, j]), i = 2:n, j = 2:n)
+  add_constraint(u[i] >= 2, i = 2:n) %>% 
+  add_constraint(u[i] - u[j] + 1 <= (n - 1) * (1 - x[i, j]), i = 2:n, j = 2:n)
 model
 ```
 


### PR DESCRIPTION
Instead of three arguments users now can (and have to) pass a full linear (in)equality to add_constraints. The function automatically extracts the lhs, rhs and direction of the (in)equality.

Signed-off-by: Dirk Schumacher <mail@dirk-schumacher.net>