### PR TITLE
Fix bug on filter expressions and indexes

### DIFF
--- a/tests/testthat/test-add-constraint.R
+++ b/tests/testthat/test-add-constraint.R
@@ -121,3 +121,10 @@ test_that("quantifier filter expressions work with add_constraint_", {
   m <- add_constraint_(m, ~x[i] == 1, i = 1:10, .dots = ~i <= 2)
   expect_equal(2, length(m$constraints))
 })
+
+test_that("indexes in filter expr. for sum_expr are correctly substituted", {
+  m <- add_variable(MIPModel(), x[i, j], i = 1:2, j = 1:2)
+  m <- add_constraint(m, sum_expr(x[i, j], i = 1:2, j == 1) == 0, j = 1:2)
+  expect_equal("x[1, 1] + x[2, 1]", as.character(m$constraints[[1]]$lhs))
+  expect_equal("0", as.character(m$constraints[[2]]$lhs))
+})

--- a/tests/testthat/test-helpers.R
+++ b/tests/testthat/test-helpers.R
@@ -73,7 +73,6 @@ test_that("bug 20161107 #103: bug in extract coefficient (1)", {
   expect_equal(0, result$constant)
 })
 
-
 test_that("bug 20161107 #103: bug in extract coefficient (2)", {
   a <- 47
   m <- MIPModel() %>%
@@ -82,4 +81,12 @@ test_that("bug 20161107 #103: bug in extract coefficient (2)", {
     add_constraint(y - a * x[i] <= 1, i = 1:2)
   result <- extract_coefficients_internal(m$constraints[[1]]$lhs[[1]])
   expect_equal(-47, result$coefficients[["x[1L]"]]$coef)
+})
+
+test_that("sum_expr returns 0 if filter expression yields 0 variables", {
+  m <- MIPModel() %>%
+    add_variable(x[i], i = 1:2) %>%
+    add_variable(y) %>%
+    add_constraint(sum_expr(x[i], i = 1:2, i == 23) == 1)
+  expect_equal(0, m$constraints[[1]]$lhs[[1]])
 })


### PR DESCRIPTION
Sometimes bound indexes were not passed to a filter expression within sum_expr. Also sum_expr now returns 0 if the filter expressions filter out all elements.