### PR TITLE
Remove LICENSE file from r package

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -11,5 +11,6 @@
 ^cran-comments\.md$
 ^README\.md$
 ^README\.Rmd$
+^LICENSE
 ^\.gitignore$
 ^\.Rhistory$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,7 +10,7 @@ Description: Model mixed integer linear programs in an algebraic way directly in
              linear constraints and objective functions. See the 'ompr'
              website <https://dirkschumacher.github.io/ompr> for more information, 
              documentation and examples.
-License: GPL-3 | file LICENSE
+License: GPL-3
 LazyData: TRUE
 RoxygenNote: 6.0.1
 URL: https://github.com/dirkschumacher/ompr


### PR DESCRIPTION
The LICENSE file is not needed for CRAN packages. Therefore it is taken out of the DESCRIPTION file and ignored when building the package.
Closes #138.