### PR TITLE
Fix interface with recent Rcpp

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -2,10 +2,10 @@
 # Generator token: 10BE3573-1514-4C36-9D1C-5A225CD40393
 
 check_for_unknown_vars_impl <- function(model, x) {
-    invisible(.Call('ompr_check_for_unknown_vars_impl', PACKAGE = 'ompr', model, x))
+    invisible(.Call('_ompr_check_for_unknown_vars_impl', PACKAGE = 'ompr', model, x))
 }
 
 is_non_linear_impl <- function(var_names, x) {
-    .Call('ompr_is_non_linear_impl', PACKAGE = 'ompr', var_names, x)
+    .Call('_ompr_is_non_linear_impl', PACKAGE = 'ompr', var_names, x)
 }
 

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -7,7 +7,7 @@ using namespace Rcpp;
 
 // check_for_unknown_vars_impl
 void check_for_unknown_vars_impl(List model, SEXP x);
-RcppExport SEXP ompr_check_for_unknown_vars_impl(SEXP modelSEXP, SEXP xSEXP) {
+RcppExport SEXP _ompr_check_for_unknown_vars_impl(SEXP modelSEXP, SEXP xSEXP) {
 BEGIN_RCPP
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< List >::type model(modelSEXP);
@@ -18,7 +18,7 @@ END_RCPP
 }
 // is_non_linear_impl
 bool is_non_linear_impl(CharacterVector var_names, SEXP x);
-RcppExport SEXP ompr_is_non_linear_impl(SEXP var_namesSEXP, SEXP xSEXP) {
+RcppExport SEXP _ompr_is_non_linear_impl(SEXP var_namesSEXP, SEXP xSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;

--- a/src/ompr-init.c
+++ b/src/ompr-init.c
@@ -6,12 +6,12 @@
 #include <stdlib.h> // for NULL
 #include <R_ext/Rdynload.h>
 
-extern SEXP ompr_check_for_unknown_vars_impl(SEXP, SEXP);
-extern SEXP ompr_is_non_linear_impl(SEXP, SEXP);
+extern SEXP _ompr_check_for_unknown_vars_impl(SEXP, SEXP);
+extern SEXP _ompr_is_non_linear_impl(SEXP, SEXP);
 
 static const R_CallMethodDef CallEntries[] = {
-    {"ompr_check_for_unknown_vars_impl", (DL_FUNC) &ompr_check_for_unknown_vars_impl, 2},
-    {"ompr_is_non_linear_impl",          (DL_FUNC) &ompr_is_non_linear_impl,          2},
+    {"_ompr_check_for_unknown_vars_impl", (DL_FUNC) &_ompr_check_for_unknown_vars_impl, 2},
+    {"_ompr_is_non_linear_impl",          (DL_FUNC) &_ompr_is_non_linear_impl,          2},
     {NULL, NULL, 0}
 };
 


### PR DESCRIPTION
It looks like things changed with Rcpp 0.12.12 - see news items about
underscores and issues #722 and #721.  This might warrant an Rcpp minimum
version of 0.12.12 but practically that affects you only when you are using
compileAttributes and not calling the initialisation skeleton code.