### PR TITLE
ignore undeclared indexes

### DIFF
--- a/R/linearopt-variables.R
+++ b/R/linearopt-variables.R
@@ -538,7 +538,7 @@ setMethod("[", signature("LinearVariableCollection", i = "ANY", j = "ANY", drop 
   }
   cols <- merge(new_indexes, index_mapping, by = join_cols)
   if (nrow(cols) != nrow(new_indexes)) {
-    stop("You used the variable '", var_name, "' with at least one index that does not exists.", call. = FALSE)
+    warning("You used the variable '", var_name, "' with ",nrow(new_indexes)," indexes but only ",nrow(cols)," indexes will be used", call. = FALSE)
   }
   new_vars <- data.table::data.table(
     variable = var_name,

--- a/R/linearopt-variables.R
+++ b/R/linearopt-variables.R
@@ -538,7 +538,8 @@ setMethod("[", signature("LinearVariableCollection", i = "ANY", j = "ANY", drop 
   }
   cols <- merge(new_indexes, index_mapping, by = join_cols)
   if (nrow(cols) != nrow(new_indexes)) {
-    warning("You used the variable '", var_name, "' with ",nrow(new_indexes)," indexes but only ",nrow(cols)," indexes will be used", call. = FALSE)
+    warning("You used the variable '", var_name, "' with ", nrow(new_indexes), 
+            " indexes but only ", nrow(cols), " indexes will be used", call. = FALSE)
   }
   new_vars <- data.table::data.table(
     variable = var_name,

--- a/tests/testthat/test-model-milp.R
+++ b/tests/testthat/test-model-milp.R
@@ -283,8 +283,8 @@ test_that("numeric - varaible sum", {
   expect_equal(constr$rhs, 3)
 })
 
-test_that("nice error message if sum_expr selected non existent variable", {
-  expect_error(
+test_that("nice warning message if sum_expr selected non existent variable", {
+  expect_warning(
     MILPModel() %>%
       add_variable(x[i], i = 1:3, i != 2) %>%
       set_objective(sum_expr(x[i], i = 1:3, i != 1)),


### PR DESCRIPTION
With this change, the model will only give a warning when indexes that do not exist with a given variable are used in a constraint