### PR TITLE
Support additional solver output

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: ompr
 Type: Package
 Title: Model and Solve Mixed Integer Linear Programs
-Version: 0.8.1.9000
+Version: 0.8.1.9001
 Authors@R: person("Dirk", "Schumacher", email = "mail@dirk-schumacher.net",
             role = c("aut", "cre"))
 Description: Model mixed integer linear programs in an algebraic way directly in R.

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,9 @@
 * Added `sum_over`, a replacement for `sum_expr` in the `MIPModel`
 * `set_bounds` for `MIPModel` now accepts (in)equalities as well (#365)
 * `MIPModel` now supports characters as variable indexes
+* A `solution` object has a new named entry called `additional_solver_output`.
+  In that place solver packages, like `ompr.roi` can store arbitrary solver
+  information. Including solver specific messages and status codes.
 
 ## Bugfixes
 

--- a/R/solution-api.R
+++ b/R/solution-api.R
@@ -8,6 +8,7 @@
 #' @param solution a named numeric vector containing the primal solution values
 #' @param solution_column_duals A function without arguments that returns a numeric vector containing the column dual solution values. `NA_real_`, if no column duals are available/defined.
 #' @param solution_row_duals A function without arguments that returns a numeric vector containing the column dual solution values. `NA_real_`, if no column duals are available/defined.
+#' @param additional_solver_output A named list of additional solver information
 #'
 #' @export
 new_solution <- function(model,
@@ -15,13 +16,10 @@ new_solution <- function(model,
                          status,
                          solution,
                          solution_column_duals = function() NA_real_,
-                         solution_row_duals = function() NA_real_) {
+                         solution_row_duals = function() NA_real_,
+                         additional_solver_output = list()) {
   stopifnot(is.numeric(objective_value))
-  stopifnot(status %in% c(
-    "infeasible",
-    "unbounded", "optimal",
-    "userlimit", "error"
-  ))
+  stopifnot(status %in% SOLUTION_STATUS_CODES)
   stopifnot(all(nchar(names(solution))))
   stopifnot(is.function(solution_column_duals), is.function(solution_row_duals))
   structure(list(
@@ -30,9 +28,16 @@ new_solution <- function(model,
     status = status,
     solution = solution,
     solution_column_duals = solution_column_duals,
-    solution_row_duals = solution_row_duals
+    solution_row_duals = solution_row_duals,
+    additional_solver_output = additional_solver_output
   ), class = "solution")
 }
+
+SOLUTION_STATUS_CODES <- c(
+  "infeasible", "feasible",
+  "unbounded", "optimal",
+  "userlimit", "error"
+)
 
 #' Get variable values from a solution
 #'

--- a/R/solution-impl.R
+++ b/R/solution-impl.R
@@ -126,7 +126,8 @@ get_row_duals.solution <- function(solution) {
   solution_row_duals <- solution$solution_row_duals()
   stopifnot(
     is.numeric(solution_row_duals),
-    !anyNA(solution_row_duals)
+    (length(solution_row_duals) == 1L && is.na(solution_row_duals)) ||
+      !anyNA(solution_row_duals)
   )
   solution_row_duals
 }

--- a/man/new_solution.Rd
+++ b/man/new_solution.Rd
@@ -10,7 +10,8 @@ new_solution(
   status,
   solution,
   solution_column_duals = function() NA_real_,
-  solution_row_duals = function() NA_real_
+  solution_row_duals = function() NA_real_,
+  additional_solver_output = list()
 )
 }
 \arguments{
@@ -25,6 +26,8 @@ new_solution(
 \item{solution_column_duals}{A function without arguments that returns a numeric vector containing the column dual solution values. `NA_real_`, if no column duals are available/defined.}
 
 \item{solution_row_duals}{A function without arguments that returns a numeric vector containing the column dual solution values. `NA_real_`, if no column duals are available/defined.}
+
+\item{additional_solver_output}{A named list of additional solver information}
 }
 \description{
 This function/class should only be used if you develop your own solver.


### PR DESCRIPTION
This adds support to pass arbitrary solver output to the solution object. This can be used to retain additional information from the solver. It builds on the idea in #194 