### PR TITLE
Improve get_solution

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -42,10 +42,14 @@ All listed functions will likely be removed at some later point the future.
 
 * `extract_constraints` now always returns a sparse matrix, even if there are 0
   constraints or variables.
-* The ordering of the `data.frame` return with `get_solution(x[i, j])` has changed.
-  Please do not depend on the ordering of the rows, but use the indexes to
-  retrieve the correct value. For example by sorting the `data.frame`, before
-  reading.
+* The row ordering of the `data.frame` returned with `get_solution(x[i, j])` has
+  slightly changed in special cases, but for the majority of calls, it
+  should stay the same. One of these special cases is if you created your
+  variable similar to `add_variable(model, x[i, j], j = ..., i = ...)`, where
+  the indexes in the variable and the quantifiers have different orderings.
+  In general, please do not depend on the ordering of the rows, but use the
+  indexes to retrieve the correct value. For example by sorting the `data.frame`
+  , before reading.
 
 # ompr 0.8.1
 

--- a/R/solution-impl.R
+++ b/R/solution-impl.R
@@ -65,6 +65,9 @@ extract_solution <- function(model, solution_vector, expr) {
       solution_names <- names(solution_vector)
       rexp_c <- regexec(instance_pattern, solution_names)
       var_index <- do.call(rbind, regmatches(solution_names, rexp_c))
+      if (ncol(var_index) == 0) {
+        abort("No variable values found given the indexes.")
+      }
       na_rows <- as.logical(apply(is.na(var_index), 1, all))
       var_index <- var_index[!na_rows, , drop = FALSE]
       var_values <- solution_vector[grepl(solution_names,
@@ -81,6 +84,10 @@ extract_solution <- function(model, solution_vector, expr) {
       result_df$variable <- var_name
       colnames(result_df) <- c(free_vars, "value", "variable")
       result_df <- result_df[, c("variable", free_vars, "value")]
+
+      # at last, for backwards compatibility order by free vars
+      ordering <- do.call(order, lapply(rev(free_vars), function(x) result_df[[x]]))
+      result_df <- result_df[ordering, ]
       return(result_df)
     }
   } else {

--- a/tests/testthat/test-solution-milp.R
+++ b/tests/testthat/test-solution-milp.R
@@ -47,27 +47,6 @@ test_that("export solutions to data.frame with index", {
   expect_equivalent(as.numeric(result$i), c(1, 2, 3))
 })
 
-test_that("export solutions to data.frame with two indexes", {
-  model <- MILPModel() %>%
-    add_variable(x[i, j], i = 1:2, j = 1:2, ub = 1)
-  solution_vars <- setNames(
-    c(1, 1, 1, 1),
-    c("x[1,1]", "x[1,2]", "x[2,1]", "x[2,2]")
-  )
-  solution <- new_solution(
-    status = "optimal",
-    model = model,
-    objective_value = 3,
-    solution = solution_vars
-  )
-  result <- get_solution(solution, x[i, j])
-  expect_s3_class(result, "data.frame")
-  expect_equivalent(result$variable, c("x", "x", "x", "x"))
-  expect_equivalent(result$value, c(1, 1, 1, 1))
-  expect_equivalent(as.numeric(result$i), c(1, 1, 2, 2))
-  expect_equivalent(as.numeric(result$j), c(1, 2, 1, 2))
-})
-
 test_that("export infeasible solutions to data.frame", {
   model <- MILPModel() %>%
     add_variable(x[i], i = 1:3, ub = 1) %>%
@@ -165,26 +144,6 @@ test_that("solution indexes should not be factors", {
     )
   )
   expect_equal(class(get_solution(solution, y[i])$i), "integer")
-})
-
-test_that("bug 20160908: solution indexes mixed up", {
-  model <- MILPModel() %>%
-    add_variable(x[i, j], i = 10:11, j = 10:12, ub = 1) %>%
-    set_objective(sum_expr(x[10, i], i = 10:12))
-  solution <- new_solution(
-    status = "optimal",
-    model = model,
-    objective_value = 3,
-    solution = setNames(
-      c(2, 2, 2, 1, 1, 1),
-      c(
-        "x[10,10]", "x[10,11]", "x[10,12]",
-        "x[11,10]", "x[11,11]", "x[11,12]"
-      )
-    )
-  )
-  sol <- get_solution(solution, x[i, j])
-  expect_equal(sol$i, c(10, 10, 10, 11, 11, 11))
 })
 
 test_that("objective_value gets the obj. value", {


### PR DESCRIPTION
* Result is now ordered by indexes. This is for legacy reasons
to try to not break code that depend on the ordering.
* Add a better error message if index combinations could not be
found.
* Remove some redundant tests


Closes #374 